### PR TITLE
feat(config): add option to use first row as column names in json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 companion.log
 /pkg
 /pkg.tgz
+yarn.lock

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export interface Config {
 
 	accessToken?: string
 	refreshToken?: string
+	useFirstRowAsColumnNames: boolean
 }
 
 export const getConfigFields = (instance: GoogleSheetsInstance): SomeCompanionConfigField[] => {
@@ -103,5 +104,12 @@ export const getConfigFields = (instance: GoogleSheetsInstance): SomeCompanionCo
 			width: 12,
 			default: false,
 		},
+		{
+            type: 'checkbox',
+            label: 'Use first row as column names (JSON ONLY)',
+            id: 'useFirstRowAsColumnNames',
+            width: 12,
+            default: false,
+        },
 	]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ class GoogleSheetsInstance extends InstanceBase<Config> {
 		referenceIndex: false,
 		pollInterval: 1.5,
 		clearTokens: false,
+		useFirstRowAsColumnNames: false,
 	}
 	public data = {
 		sheetData: new Map<string, any>(),


### PR DESCRIPTION
Added a new configuration option `useFirstRowAsColumnNames` to allow users to specify if the first row of the Google Sheet should be used as column names in the JSON output. Updated the data processing logic to trim spaces from column names and data values. Specifically for vMix data sourcing.